### PR TITLE
🎨 added link to MQT website

### DIFF
--- a/src/mqt/benchviewer/templates/index.html
+++ b/src/mqt/benchviewer/templates/index.html
@@ -70,7 +70,12 @@
 
     <div class="col-md-12" style="height: 80px"></div>
     <p align="center">
-      <img src="{{ url_for('static', filename='mqt_dark.png')}}" width="20%" />
+      <a href="https://www.cda.cit.tum.de/research/quantum/mqt/">
+        <img
+          src="{{ url_for('static', filename='mqt_dark.png')}}"
+          width="20%"
+        />
+      </a>
     </p>
     <div class="container">
       <h1>


### PR DESCRIPTION
This PR links the MQT Logo to the [MQT website](https://www.cda.cit.tum.de/research/quantum/mqt/).