### PR TITLE
🐛 Remove superfluous classical register in QFT algorithm

### DIFF
--- a/src/mqt/bench/benchmarks/qft.py
+++ b/src/mqt/bench/benchmarks/qft.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library import QFT
 
 
@@ -11,8 +11,7 @@ def create_circuit(num_qubits: int) -> QuantumCircuit:
     num_qubits -- number of qubits of the returned quantum circuit
     """
     q = QuantumRegister(num_qubits, "q")
-    c = ClassicalRegister(num_qubits, "c")
-    qc = QuantumCircuit(q, c, name="qft")
+    qc = QuantumCircuit(q, name="qft")
     qc.compose(QFT(num_qubits=num_qubits), inplace=True)
     qc.measure_all()
 


### PR DESCRIPTION
This PR fixes a small bug in the QFT benchmark discovered while trying to verify some MQT Bench circuits using QCEC.
The QFT benchmark would contain an additional classical register that was never used because `measure_all` creates its own classical register and adds it to the circuit.