### PR TITLE
Add basic CLI around get_benchmark()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ module = ["pytket.*", "qiskit_finance.*"]
 implicit_reexport = true
 
 [[tool.mypy.overrides]]
-module = ["qiskit.*", "qiskit_finance.*", "joblib.*", "networkx.*", "pandas.*", "qiskit_algorithms.*", "qiskit_ibm_runtime.*"]
+module = ["qiskit.*", "qiskit_finance.*", "joblib.*", "networkx.*", "pandas.*", "qiskit_algorithms.*", "qiskit_ibm_runtime.*", "pytest_console_scripts.*"]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.2"]
+test = ["pytest>=7.2", "pytest-console-scripts>=1.4"]
 coverage = ["mqt.bench[test]", "pytest-cov[toml]"]
 docs = [
     "furo>=2023.08.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = ["mqt.bench[coverage, docs]"]
 "mqt.bench" = "mqt.benchviewer.main:start_server"
 "create_mqt_bench_zip" = "mqt.bench.utils:create_zip_file"
 "generate_mqt_bench" = "mqt.bench.benchmark_generator:generate"
+"mqt.bench.cli" = "mqt.bench.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/cda-tum/mqtbench"

--- a/src/mqt/bench/benchmark_generator.py
+++ b/src/mqt/bench/benchmark_generator.py
@@ -393,8 +393,6 @@ def get_benchmark(
         msg = "compiler_settings must be of type CompilerSettings or None."  # type: ignore[unreachable]
         raise ValueError(msg)
 
-    assert (compiler_settings.tket is not None) or (compiler_settings.qiskit is not None)
-
     independent_level = 1
     if level in ("indep", independent_level):
         if compiler == "qiskit":

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -1,0 +1,61 @@
+import argparse
+
+from mqt.bench import QiskitSettings, TKETSettings, get_benchmark, CompilerSettings
+from pytket import Circuit
+from pytket.qasm import circuit_to_qasm_str
+from qiskit import QuantumCircuit
+from qiskit.qasm2 import dumps as qiskit_circuit_to_str
+
+
+def main() -> None:
+    """
+    Invoke :func:`get_benchmark` exactly once with the specified arguments.
+
+    The resulting QASM string is printed to the standard output stream;
+    no other output is generated.
+    """
+
+    parser = argparse.ArgumentParser(description="Generate a single benchmark")
+    parser.add_argument("--level", type=str,
+                        help='Level to generate benchmarks for ("alg", "indep", "nativegates" or "mapped")',
+                        required=True)
+    parser.add_argument("--algorithm", type=str, help="Name of the benchmark", required=True)
+    parser.add_argument("--num-qubits", type=int, help="Number of Qubits")
+    parser.add_argument("--compiler", type=str, help="Name of the compiler")
+    parser.add_argument("--qiskit-optimization-level", type=int, help="Qiskit compiler optimization level")
+    parser.add_argument("--tket-placement", type=str, help="TKET placement")
+    parser.add_argument("--native-gate-set", type=str, help="Name of the provider")
+    parser.add_argument("--device", type=str, help="Name of the device")
+    args = parser.parse_args()
+
+    qiskit_settings: QiskitSettings | None = None
+    if args.qiskit_optimization_level is not None:
+        qiskit_settings = QiskitSettings(args.qiskit_optimization_level)
+
+    tket_settings: TKETSettings | None = None
+    if args.tket_placement is not None:
+        tket_settings = TKETSettings(args.tket_placement)
+
+    # Note: Assertions about argument validity are in get_benchmark()
+
+    result = get_benchmark(
+        benchmark_name=args.algorithm,
+        level=args.level,
+        circuit_size=args.num_qubits,
+        compiler=args.compiler,
+        compiler_settings=CompilerSettings(
+            qiskit=qiskit_settings,
+            tket=tket_settings,
+        ),
+        provider_name=args.native_gate_set,
+        device_name=args.device,
+    )
+
+    if isinstance(result, QuantumCircuit):
+        qasm_str = qiskit_circuit_to_str(result)
+    elif isinstance(result, Circuit):
+        qasm_str = circuit_to_qasm_str(result)
+    else:
+        raise TypeError(f"Got unknown circuit type from get_benchmark: {type(result)}")
+
+    print(qasm_str)

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -75,7 +75,7 @@ def parse_benchmark_name_and_instance(algorithm: str) -> tuple[str, str | None]:
     as expected by :func:`get_benchmark`.
     """
 
-    if algorithm.startswith("shor_") or algorithm.startswith("groundstate_"):
+    if algorithm.startswith(("shor_", "groundstate_")):
         as_list = algorithm.split("_", 2)
         assert len(as_list) == 2
         return cast(tuple[str, str], tuple(as_list))

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -25,7 +25,7 @@ def main() -> None:
         required=True,
     )
     parser.add_argument("--algorithm", type=str, help="Name of the benchmark", required=True)
-    parser.add_argument("--num-qubits", type=int, help="Number of Qubits")
+    parser.add_argument("--num-qubits", type=int, help="Number of Qubits", required=True)
     parser.add_argument("--compiler", type=str, help="Name of the compiler")
     parser.add_argument("--qiskit-optimization-level", type=int, help="Qiskit compiler optimization level")
     parser.add_argument("--tket-placement", type=str, help="TKET placement")

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import cast
 
 from pytket.qasm import circuit_to_qasm_str
 from qiskit import QuantumCircuit
@@ -43,8 +44,13 @@ def main() -> None:
 
     # Note: Assertions about argument validity are in get_benchmark()
 
+    # Temporary workaround to "get things working" with benchmark instances.
+    # This special treatment should be removed as soon as instance handling has been refactored in get_benchmark().
+    benchmark_name, benchmark_instance = parse_benchmark_name_and_instance(args.algorithm)
+
     result = get_benchmark(
-        benchmark_name=args.algorithm,
+        benchmark_name=benchmark_name,
+        benchmark_instance_name=benchmark_instance,
         level=args.level,
         circuit_size=args.num_qubits,
         compiler=args.compiler,
@@ -61,3 +67,17 @@ def main() -> None:
         return
 
     print(circuit_to_qasm_str(result))
+
+
+def parse_benchmark_name_and_instance(algorithm: str) -> tuple[str, str | None]:
+    """
+    Parse an algorithm name like "shor_xlarge" into a benchmark and instance name
+    as expected by :func:`get_benchmark`.
+    """
+
+    if algorithm.startswith("shor_") or algorithm.startswith("groundstate_"):
+        as_list = algorithm.split("_", 2)
+        assert len(as_list) == 2
+        return cast(tuple[str, str], tuple(as_list))
+
+    return algorithm, None

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -34,11 +34,11 @@ def main() -> None:
     parser.add_argument("--device", type=str, help="Name of the device")
     args = parser.parse_args()
 
-    qiskit_settings: QiskitSettings | None = None
+    qiskit_settings = QiskitSettings()
     if args.qiskit_optimization_level is not None:
         qiskit_settings = QiskitSettings(args.qiskit_optimization_level)
 
-    tket_settings: TKETSettings | None = None
+    tket_settings = TKETSettings()
     if args.tket_placement is not None:
         tket_settings = TKETSettings(args.tket_placement)
 
@@ -58,11 +58,7 @@ def main() -> None:
     )
 
     if isinstance(result, QuantumCircuit):
-        qasm_str = qiskit_circuit_to_str(result)
-    elif isinstance(result, Circuit):
-        qasm_str = circuit_to_qasm_str(result)
-    else:
-        msg = f"Got unknown circuit type from get_benchmark: {type(result)}"
-        raise TypeError(msg)
-
-    print(qasm_str)
+        print(qiskit_circuit_to_str(result))
+        return
+    
+    print(circuit_to_qasm_str(result))

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import argparse
 
-from mqt.bench import QiskitSettings, TKETSettings, get_benchmark, CompilerSettings
 from pytket import Circuit
 from pytket.qasm import circuit_to_qasm_str
 from qiskit import QuantumCircuit
 from qiskit.qasm2 import dumps as qiskit_circuit_to_str
+
+from mqt.bench import CompilerSettings, QiskitSettings, TKETSettings, get_benchmark
 
 
 def main() -> None:
@@ -16,9 +19,12 @@ def main() -> None:
     """
 
     parser = argparse.ArgumentParser(description="Generate a single benchmark")
-    parser.add_argument("--level", type=str,
-                        help='Level to generate benchmarks for ("alg", "indep", "nativegates" or "mapped")',
-                        required=True)
+    parser.add_argument(
+        "--level",
+        type=str,
+        help='Level to generate benchmarks for ("alg", "indep", "nativegates" or "mapped")',
+        required=True,
+    )
     parser.add_argument("--algorithm", type=str, help="Name of the benchmark", required=True)
     parser.add_argument("--num-qubits", type=int, help="Number of Qubits")
     parser.add_argument("--compiler", type=str, help="Name of the compiler")
@@ -56,6 +62,7 @@ def main() -> None:
     elif isinstance(result, Circuit):
         qasm_str = circuit_to_qasm_str(result)
     else:
-        raise TypeError(f"Got unknown circuit type from get_benchmark: {type(result)}")
+        msg = f"Got unknown circuit type from get_benchmark: {type(result)}"
+        raise TypeError(msg)
 
     print(qasm_str)

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 
-from pytket import Circuit
 from pytket.qasm import circuit_to_qasm_str
 from qiskit import QuantumCircuit
 from qiskit.qasm2 import dumps as qiskit_circuit_to_str
@@ -60,5 +59,5 @@ def main() -> None:
     if isinstance(result, QuantumCircuit):
         print(qiskit_circuit_to_str(result))
         return
-    
+
     print(circuit_to_qasm_str(result))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,14 @@
-from mqt.bench import get_benchmark, CompilerSettings, QiskitSettings
-from pytest_console_scripts import ScriptRunner
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from qiskit.qasm2 import dumps
+
+from mqt.bench import CompilerSettings, QiskitSettings, get_benchmark
+
+if TYPE_CHECKING:
+    from pytest_console_scripts import ScriptRunner
 
 
 # fmt: off
@@ -48,7 +55,6 @@ from qiskit.qasm2 import dumps
         ))),
     ],
 )
-# fmt: on
 def test_cli(args: list[str], expected_output: str, script_runner: ScriptRunner) -> None:
     ret = script_runner.run(["mqt.bench.cli", *args])
     assert ret.success
@@ -76,7 +82,6 @@ def test_cli(args: list[str], expected_output: str, script_runner: ScriptRunner)
          ], ""),
     ],
 )
-# fmt: on
 def test_cli_errors(args: list[str], expected_output: str, script_runner: ScriptRunner) -> None:
     ret = script_runner.run(["mqt.bench.cli", *args])
     assert not ret.success

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,83 @@
+from mqt.bench import get_benchmark, CompilerSettings, QiskitSettings
+from pytest_console_scripts import ScriptRunner
+import pytest
+from qiskit.qasm2 import dumps
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    ("args", "expected_output"),
+    [
+        ([
+             "--level", "alg",
+             "--algorithm", "ghz",
+             "--num-qubits", "10",
+         ], dumps(get_benchmark(level="alg", benchmark_name="ghz", circuit_size=10))),
+        ([
+             "--level", "alg",
+             "--algorithm", "shor_xsmall",
+             "--num-qubits", "10",
+         ], "OPENQASM 2.0;"),  # Note: shor is non-deterministic, so just a basic sanity check
+        ([
+             "--level", "alg",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+         ], dumps(get_benchmark(level="alg", benchmark_name="ghz", circuit_size=20))),
+        ([
+             "--level", "indep",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+             "--compiler", "qiskit",
+         ], dumps(get_benchmark(level="indep", benchmark_name="ghz", circuit_size=20, compiler="qiskit"))),
+        ([
+             "--level", "mapped",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+             "--compiler", "qiskit",
+             "--qiskit-optimization-level", "2",
+             "--native-gate-set", "ibm",
+             "--device", "ibm_montreal",
+         ], dumps(get_benchmark(
+            level="mapped",
+            benchmark_name="ghz",
+            circuit_size=20,
+            compiler="qiskit",
+            compiler_settings=CompilerSettings(QiskitSettings(optimization_level=2)),
+            provider_name="ibm",
+            device_name="ibm_montreal",
+        ))),
+    ],
+)
+# fmt: on
+def test_cli(args: list[str], expected_output: str, script_runner: ScriptRunner) -> None:
+    ret = script_runner.run(["mqt.bench.cli", *args])
+    assert ret.success
+    assert expected_output in ret.stdout
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    ("args", "expected_output"),
+    [
+        ([], "usage: mqt.bench.cli"),
+        (["asd"], "usage: mqt.bench.cli"),
+        (["--benchmark", "ae"], "usage: mqt.bench.cli"),
+        # Note: We don't care about the actual error messages in most cases
+        ([
+             "--level", "indep",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+             # Missing compiler option
+         ], ""),
+        ([
+             "--level", "alg",
+             "--algorithm", "not-a-valid-benchmark",
+             "--num-qubits", "20",
+         ], ""),
+    ],
+)
+# fmt: on
+def test_cli_errors(args: list[str], expected_output: str, script_runner: ScriptRunner) -> None:
+    ret = script_runner.run(["mqt.bench.cli", *args])
+    assert not ret.success
+    assert expected_output in ret.stderr


### PR DESCRIPTION
Mainly to be used automatically by tooling.
Options are simple CLI options for now, but should probably become more dynamic in the future (does argparse support dynamic/unregistered options?).