### PR TITLE
Corrected the readme ghz-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following code gives an example on the usage:
 from mqt.bench import get_benchmark
 
 # get a benchmark circuit on algorithmic level representing the GHZ state with 5 qubits
-qc_algorithmic_level = get_benchmark(benchmark_name="dj", level="alg", circuit_size=5)
+qc_algorithmic_level = get_benchmark(benchmark_name="ghz", level="alg", circuit_size=5)
 
 # draw the circuit
 print(qc_algorithmic_level.draw())


### PR DESCRIPTION
Corrected the README example: The description of getting representing the GHZ-state used the incorrect `benchmark_name='dj'`  ('Deutsch-Jozsa'). Updated the example to use the `benchmark_name='ghz'` .