### PR TITLE
🐛 Verify provider and device availability based on selected level

### DIFF
--- a/src/mqt/bench/benchmark_generator.py
+++ b/src/mqt/bench/benchmark_generator.py
@@ -439,11 +439,12 @@ def get_benchmark(
         if compiler == "tket":
             return tket_helper.get_native_gates_level(qc, provider, circuit_size, False, True)
 
+    if device_name not in get_available_device_names():
+        msg = f"Selected device_name must be in {get_available_device_names()}."
+        raise ValueError(msg)
+
     mapped_level = 3
     if level in ("mapped", mapped_level):
-        if device_name not in get_available_device_names():
-            msg = f"Selected device_name must be in {get_available_device_names()}."
-            raise ValueError(msg)
         device = get_device_by_name(device_name)
         if compiler == "qiskit":
             assert compiler_settings.qiskit is not None

--- a/src/mqt/bench/benchmark_generator.py
+++ b/src/mqt/bench/benchmark_generator.py
@@ -426,12 +426,11 @@ def get_benchmark(
         if compiler == "tket":
             return tket_helper.get_indep_level(qc, circuit_size, False, True)
 
-    if provider_name not in get_available_provider_names():
-        msg = f"Selected provider_name must be in {get_available_provider_names()}."
-        raise ValueError(msg)
-
     native_gates_level = 2
     if level in ("nativegates", native_gates_level):
+        if provider_name not in get_available_provider_names():
+            msg = f"Selected provider_name must be in {get_available_provider_names()}."
+            raise ValueError(msg)
         provider = get_provider_by_name(provider_name)
         if compiler == "qiskit":
             assert compiler_settings.qiskit is not None
@@ -440,12 +439,11 @@ def get_benchmark(
         if compiler == "tket":
             return tket_helper.get_native_gates_level(qc, provider, circuit_size, False, True)
 
-    if device_name not in get_available_device_names():
-        msg = f"Selected device_name must be in {get_available_device_names()}."
-        raise ValueError(msg)
-
     mapped_level = 3
     if level in ("mapped", mapped_level):
+        if device_name not in get_available_device_names():
+            msg = f"Selected device_name must be in {get_available_device_names()}."
+            raise ValueError(msg)
         device = get_device_by_name(device_name)
         if compiler == "qiskit":
             assert compiler_settings.qiskit is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,14 @@ if TYPE_CHECKING:
              "--compiler", "qiskit",
          ], dumps(get_benchmark(level="indep", benchmark_name="ghz", circuit_size=20, compiler="qiskit"))),
         ([
+             "--level", "nativegates",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+             "--compiler", "qiskit",
+             "--native-gate-set", "ibm",
+             "--device", None,
+         ], dumps(get_benchmark(level="nativegates", benchmark_name="ghz", circuit_size=20, compiler="qiskit", provider_name="ibm"))),
+        ([
              "--level", "mapped",
              "--algorithm", "ghz",
              "--num-qubits", "20",
@@ -61,6 +69,22 @@ if TYPE_CHECKING:
              "--num-qubits", "20",
              "--compiler", "qiskit",
              "--qiskit-optimization-level", "2",
+             "--device", "ibm_montreal",
+         ], dumps(get_benchmark(
+            level="mapped",
+            benchmark_name="ghz",
+            circuit_size=20,
+            compiler="qiskit",
+            compiler_settings=CompilerSettings(QiskitSettings(optimization_level=2)),
+            device_name="ibm_montreal",
+        ))),
+        ([
+             "--level", "mapped",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+             "--compiler", "qiskit",
+             "--qiskit-optimization-level", "2",
+             "--native-gate-set", None,
              "--device", "ibm_montreal",
          ], dumps(get_benchmark(
             level="mapped",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,21 @@ if TYPE_CHECKING:
             provider_name="ibm",
             device_name="ibm_montreal",
         ))),
+        ([
+             "--level", "mapped",
+             "--algorithm", "ghz",
+             "--num-qubits", "20",
+             "--compiler", "qiskit",
+             "--qiskit-optimization-level", "2",
+             "--device", "ibm_montreal",
+         ], dumps(get_benchmark(
+            level="mapped",
+            benchmark_name="ghz",
+            circuit_size=20,
+            compiler="qiskit",
+            compiler_settings=CompilerSettings(QiskitSettings(optimization_level=2)),
+            device_name="ibm_montreal",
+        ))),
     ],
 )
 def test_cli(args: list[str], expected_output: str, script_runner: ScriptRunner) -> None:


### PR DESCRIPTION
This PR addresses a bug where the provider's availability was checked, even when the level was set to ``mapped``. This caused an issue if ``provider_name`` was not provided in ``mqt.bench.cli`` while using the ``mapped`` level.