### PR TITLE
🔥 removing obsolete code for importlib backwards compatibility

### DIFF
--- a/src/mqt/bench/devices/provider.py
+++ b/src/mqt/bench/devices/provider.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 
-import sys
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from importlib import resources
 from typing import TYPE_CHECKING
-
-if TYPE_CHECKING or sys.version_info >= (3, 10, 0):
-    from importlib import resources
-else:
-    import importlib_resources as resources
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from .device import Device
-
-from abc import ABC, abstractmethod
 
 
 @dataclass

--- a/src/mqt/bench/utils.py
+++ b/src/mqt/bench/utils.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-import sys
+from dataclasses import dataclass
 from datetime import date
+from importlib import import_module, metadata, resources
 from pathlib import Path
 from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover
-    from types import ModuleType
-
-from importlib import import_module
 
 import networkx as nx
 import numpy as np
@@ -19,16 +15,10 @@ from qiskit import QuantumCircuit
 from qiskit import __version__ as __qiskit_version__
 from qiskit.converters import circuit_to_dag
 
-if TYPE_CHECKING or sys.version_info >= (3, 10, 0):  # pragma: no cover
-    from importlib import metadata, resources
-else:
-    import importlib_metadata as metadata
-    import importlib_resources as resources
-
 if TYPE_CHECKING:  # pragma: no cover
-    from qiskit_optimization import QuadraticProgram
+    from types import ModuleType
 
-from dataclasses import dataclass
+    from qiskit_optimization import QuadraticProgram
 
 
 @dataclass

--- a/src/mqt/bench/viewer/backend.py
+++ b/src/mqt/bench/viewer/backend.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import io
 import os
 import re
-import sys
 from dataclasses import dataclass
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -15,12 +15,6 @@ import pandas as pd
 import requests
 from packaging import version
 from tqdm import tqdm
-
-if TYPE_CHECKING or sys.version_info >= (3, 10, 0):  # pragma: no cover
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
-
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterable

--- a/tests/test_benchviewer.py
+++ b/tests/test_benchviewer.py
@@ -2,19 +2,13 @@
 
 from __future__ import annotations
 
-import sys
+from importlib import resources
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
 from mqt.bench.viewer import Backend, BenchmarkConfiguration, Server, backend
 from mqt.bench.viewer.main import app
-
-if TYPE_CHECKING or sys.version_info >= (3, 10, 0):  # pragma: no cover
-    from importlib import resources
-else:
-    import importlib_resources as resources
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR removes some code that has become obsolete at the time we moved the minimum supported Python version to 3.10.