### PR TITLE
🐳 MQT Bench Docker Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,275 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,pycharm,jupyternotebooks
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,pycharm,jupyternotebooks
+
+### Manually added
+/hist_output/*
+/qasm_output/*
+
+*.qasm
+
+.idea/*
+*.DS_Store
+*hist_output/*png
+
+### JupyterNotebooks ###
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+### VSCode ###
+.vscode/settings.json
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# End of https://www.toptal.com/developers/gitignore/api/python,pycharm,jupyternotebooks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: 🐳 Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: munichquantumtoolkit
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: munichquantumtoolkit/mqt-bench
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1.9
+
+# Adapted from https://hynek.me/articles/docker-uv/
+FROM ubuntu:noble AS build
+
+SHELL ["sh", "-exc"]
+
+### Start build prep.
+
+RUN <<EOT
+apt-get update -qy
+apt-get install -qyy \
+    -o APT::Install-Recommends=false \
+    -o APT::Install-Suggests=false \
+    python3.12-dev \
+    git
+EOT
+
+# Install `uv`
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# - Silence uv complaining about not being able to use hard links,
+# - tell uv to byte-compile packages for faster application startups,
+# - prevent uv from accidentally downloading isolated Python builds,
+# - pick a Python,
+# - and finally declare `/mqt-bench` as the target for `uv sync`.
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PYTHON=python3.12 \
+    UV_PROJECT_ENVIRONMENT=/mqt-bench
+
+### End build prep.
+
+# Synchronize DEPENDENCIES and install the APPLICATION from `/src`.
+# `/src` will NOT be copied into the runtime container.
+COPY . /src
+RUN --mount=type=cache,target=/root/.cache \
+    cd /src && uv sync --locked --no-dev --no-editable
+
+##########################################################################
+
+FROM ubuntu:noble
+SHELL ["sh", "-exc"]
+
+# Add the application virtualenv to search path.
+ENV PATH=/mqt-bench/bin:$PATH
+
+# Run application as non-root user.
+RUN <<EOT
+groupadd -r mqt-bench
+useradd -r -d /mqt-bench -g mqt-bench -N mqt-bench
+EOT
+
+ENTRYPOINT ["mqt.bench.cli"]
+STOPSIGNAL SIGINT
+
+# Note how the runtime dependencies differ from build-time ones.
+# Notably, there is no uv either!
+RUN <<EOT
+apt-get update -qy
+apt-get install -qyy \
+    -o APT::Install-Recommends=false \
+    -o APT::Install-Suggests=false \
+    python3.12 \
+    libpython3.12
+
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+EOT
+
+# Copy the pre-built `/app` directory to the runtime container
+# and change the ownership to user app and group app in one step.
+COPY --from=build --chown=mqt-bench:mqt-bench /mqt-bench /mqt-bench
+
+USER mqt-bench
+WORKDIR /mqt-bench
+
+RUN <<EOT
+python -V
+mqt.bench.cli --help
+EOT

--- a/src/mqt/bench/cli.py
+++ b/src/mqt/bench/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from importlib import metadata
 from typing import cast
 
 from pytket.qasm import circuit_to_qasm_str
@@ -12,13 +13,27 @@ from qiskit.qasm2 import dumps as qiskit_circuit_to_str
 from . import CompilerSettings, QiskitSettings, TKETSettings, get_benchmark
 
 
+class CustomArgumentParser(argparse.ArgumentParser):
+    """Custom argument parser that includes version information in the help message."""
+
+    def format_help(self) -> str:
+        """Include version information in the help message."""
+        help_message = super().format_help()
+        version_info = (
+            f"\nMQT Bench version: {metadata.version('mqt.bench')}\n"
+            f"Qiskit version: {metadata.version('qiskit')}\n"
+            f"TKET version: {metadata.version('pytket')}\n"
+        )
+        return help_message + version_info
+
+
 def main() -> None:
     """Invoke :func:`get_benchmark` exactly once with the specified arguments.
 
     The resulting QASM string is printed to the standard output stream;
     no other output is generated.
     """
-    parser = argparse.ArgumentParser(description="Generate a single benchmark")
+    parser = CustomArgumentParser(description="Generate a single benchmark")
     parser.add_argument(
         "--level",
         type=str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,7 @@ if TYPE_CHECKING:
             compiler_settings=CompilerSettings(QiskitSettings(optimization_level=2)),
             device_name="ibm_montreal",
         ))),
+        (["--help"], "usage: mqt.bench.cli"),
     ],
 )
 def test_cli(args: list[str], expected_output: str, script_runner: ScriptRunner) -> None:


### PR DESCRIPTION
This PR sets up an MQT Bench docker container so that the CLI can be run from a stable environment with locked dependencies.
The dockerfile is based on the excellent guide at https://hynek.me/articles/docker-uv/

The PR also introduces a new CI workflow for building and publishing the containers to Docker Hub under the `munichquantumtoolkit/mqt-bench` project.