### PR TITLE
:bug: Fix an outdated reference to PennyLane

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ print(qc_algorithmic_level.draw())
 
 ## Availability as a PennyLane Dataset
 
-MQT Bench is also available as a [PennyLane dataset](https://pennylane.ai/datasets/other/mqt-bench).
+MQT Bench is also available as a [PennyLane dataset](https://pennylane.ai/datasets/single-dataset/mqt-bench).
 
 ## References
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ MQT Bench is a tool for benchmarking quantum software tools developed as part of
 
 We recommend you to start with the :doc:`quickstart guide <Quickstart>`.
 If you are interested in the theory behind MQT Bench, have a look at the publication :cite:labelpar:`quetschlich2023mqtbench`.
-Furthermore, MQT Bench is also available as a `PennyLane dataset <https://pennylane.ai/datasets/other/mqt-bench>`_.
+Furthermore, MQT Bench is also available as a `PennyLane dataset <https://pennylane.ai/datasets/single-dataset/mqt-bench>`_.
 
 We appreciate any feedback and contributions to the project. If you want to contribute, you can find more information in the :doc:`Contribution <Contributing>` guide. If you are having trouble with the installation or the usage of MQT Bench, please let us know at our :doc:`Support <Support>` page.
 

--- a/frontend/src/mqt/bench/viewer/templates/index.html
+++ b/frontend/src/mqt/bench/viewer/templates/index.html
@@ -99,7 +99,7 @@
       <p>
         In order to create a benchmark set according to your needs, simply fill
         out the form below. Furthermore, MQT Bench is also available as a
-        <a href="https://pennylane.ai/datasets/other/mqt-bench" target="_blank"
+        <a href="https://pennylane.ai/datasets/single-dataset/mqt-bench" target="_blank"
           >PennyLane dataset</a
         >.
       </p>
@@ -634,7 +634,7 @@
             <p>
               MQT Bench is also available as a
               <a
-                href="https://pennylane.ai/datasets/other/mqt-bench"
+                href="https://pennylane.ai/datasets/single-dataset/mqt-bench"
                 target="_blank"
                 >PennyLane dataset</a
               >.

--- a/frontend/src/mqt/bench/viewer/templates/index.html
+++ b/frontend/src/mqt/bench/viewer/templates/index.html
@@ -99,7 +99,9 @@
       <p>
         In order to create a benchmark set according to your needs, simply fill
         out the form below. Furthermore, MQT Bench is also available as a
-        <a href="https://pennylane.ai/datasets/single-dataset/mqt-bench" target="_blank"
+        <a
+          href="https://pennylane.ai/datasets/single-dataset/mqt-bench"
+          target="_blank"
           >PennyLane dataset</a
         >.
       </p>


### PR DESCRIPTION
This PR fixes an outdated hyperlink to PennyLane.