### PR TITLE
👷 only run docker build if credentials are available

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,19 +26,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Check whether the Docker credentials are available as secrets. If both are set, then set a boolean flag and export it to the environment.
+      - name: Check Docker credentials
+        id: docker_credentials
+        run: |
+          if [ -z "${{ secrets.DOCKERHUB_USERNAME }}" ] || [ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+              echo "::notice title=Docker credentials are not set.::If you want to run this job on a PR from a fork, you need to set the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets in the repository settings."
+              echo "DOCKER_CREDENTIALS_SET=false" >> $GITHUB_ENV
+          else
+              echo "DOCKER_CREDENTIALS_SET=true" >> $GITHUB_ENV
+          fi
+
       - name: Login to Docker Hub
+        if: steps.docker_credentials.outputs.DOCKER_CREDENTIALS_SET == 'true'
         uses: docker/login-action@v3
         with:
-          username: munichquantumtoolkit
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
+        if: steps.docker_credentials.outputs.DOCKER_CREDENTIALS_SET == 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: munichquantumtoolkit/mqt-bench
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/mqt-bench
 
       - name: Build and push Docker image
+        if: steps.docker_credentials.outputs.DOCKER_CREDENTIALS_SET == 'true'
         id: push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,31 +28,31 @@ jobs:
 
       # Check whether the Docker credentials are available as secrets. If both are set, then set a boolean flag and export it to the environment.
       - name: Check Docker credentials
-        id: docker_credentials
         run: |
           if [ -z "${{ secrets.DOCKERHUB_USERNAME }}" ] || [ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
               echo "::notice title=Docker credentials are not set.::If you want to run this job on a PR from a fork, you need to set the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets in the repository settings."
               echo "DOCKER_CREDENTIALS_SET=false" >> $GITHUB_ENV
           else
+              echo "::notice title=Docker credentials are set.::The subsequent steps will run."
               echo "DOCKER_CREDENTIALS_SET=true" >> $GITHUB_ENV
           fi
 
       - name: Login to Docker Hub
-        if: steps.docker_credentials.outputs.DOCKER_CREDENTIALS_SET == 'true'
+        if: env.DOCKER_CREDENTIALS_SET == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
-        if: steps.docker_credentials.outputs.DOCKER_CREDENTIALS_SET == 'true'
+        if: env.DOCKER_CREDENTIALS_SET == 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/mqt-bench
 
       - name: Build and push Docker image
-        if: steps.docker_credentials.outputs.DOCKER_CREDENTIALS_SET == 'true'
+        if: env.DOCKER_CREDENTIALS_SET == 'true'
         id: push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
This PR adapts the docker CI workflow to only run the build whenever all the credentials are appropriately set.
As a consequence, it does not run on PRs from forks by default, but only if the forks set the required credentials in their repo settings.