### PR TITLE
🐛 fix static files not being installed with frontend

### DIFF
--- a/frontend/pyproject.toml
+++ b/frontend/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
 [project.scripts]
 "mqt.bench.viewer" = "mqt.bench.viewer.main:start_server"
 
+
+[tool.setuptools.package-data]
+"mqt.bench.viewer" = ["static/**/*", "templates/*"]
+
+
 [tool.pytest.ini_options]
 minversion = "7.2"
 testpaths = ["tests"]


### PR DESCRIPTION
This PR fixes an issue where the static files for the MQT Bench frontend would not be installed with the frontend. This would prevent the server from properly starting.