### PR TITLE
🔧 Configure incompatibility with Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,10 @@ source = "vcs"
 version-file = "src/mqt/bench/_version.py"
 
 
+[tool.check-sdist]
+sdist-only = ["src/mqt/bench/_version.py"]
+
+
 [tool.pytest]
 minversion = "9.0"
 testpaths = ["tests"]


### PR DESCRIPTION
## Description

This PR configures MQT bench to be incompatible with Python 3.14.1 because of an issue with `networkx` caused by https://github.com/python/cpython/issues/142214.

Fixes #773 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
