### PR TITLE
🚸 Fix compatibility with Qiskit 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- 🚸 Fix compatibility with Qiskit 2.4 ([#895]) ([**@burgholzer**])
+
 ## [2.2.1] - 2026-03-23
 
 Rerelease of 2.2.0: no code changes. The CD pipeline failed for v2.2.0 and release artifacts are immutable, so this patch version republishes the same release contents.
@@ -115,6 +119,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#895]: https://github.com/munich-quantum-toolkit/bench/pull/895
 [#865]: https://github.com/munich-quantum-toolkit/bench/pull/865
 [#816]: https://github.com/munich-quantum-toolkit/bench/pull/816
 [#814]: https://github.com/munich-quantum-toolkit/bench/pull/814

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-04-20
+
 ### Fixed
 
 - 🚸 Fix compatibility with Qiskit 2.4 ([#895]) ([**@burgholzer**])
@@ -109,7 +111,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/bench/compare/v2.2.1...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/bench/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/munich-quantum-toolkit/bench/releases/tag/v2.2.2
 [2.2.1]: https://github.com/munich-quantum-toolkit/bench/releases/tag/v2.2.1
 [2.2.0]: https://github.com/munich-quantum-toolkit/bench/releases/tag/v2.2.0
 [2.1.0]: https://github.com/munich-quantum-toolkit/bench/releases/tag/v2.1.0

--- a/src/mqt/bench/targets/devices/ibm.py
+++ b/src/mqt/bench/targets/devices/ibm.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 from qiskit.providers.fake_provider import GenericBackendV2
 
-from ..gatesets import get_gateset_without_control_flow_ops
+from ..gatesets import get_gateset
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ def get_ibm_falcon_27() -> Target:
     backend = GenericBackendV2(
         num_qubits=27,
         coupling_map=cmap,
-        basis_gates=get_gateset_without_control_flow_ops("ibm_falcon"),
+        basis_gates=get_gateset("ibm_falcon"),
         noise_info=True,
         seed=DEFAULT_SEED,
         control_flow=True,
@@ -398,7 +398,7 @@ def get_ibm_falcon_127() -> Target:
     backend = GenericBackendV2(
         num_qubits=127,
         coupling_map=cmap,
-        basis_gates=get_gateset_without_control_flow_ops("ibm_falcon"),
+        basis_gates=get_gateset("ibm_falcon"),
         noise_info=True,
         seed=DEFAULT_SEED,
         control_flow=True,
@@ -415,7 +415,7 @@ def get_ibm_eagle_127() -> Target:
     backend = GenericBackendV2(
         num_qubits=127,
         coupling_map=cmap,
-        basis_gates=get_gateset_without_control_flow_ops("ibm_eagle"),
+        basis_gates=get_gateset("ibm_eagle"),
         noise_info=True,
         seed=DEFAULT_SEED,
         control_flow=True,
@@ -733,7 +733,7 @@ def get_ibm_heron_133() -> Target:
     backend = GenericBackendV2(
         num_qubits=133,
         coupling_map=cmap,
-        basis_gates=get_gateset_without_control_flow_ops("ibm_heron"),
+        basis_gates=get_gateset("ibm_heron"),
         noise_info=True,
         seed=DEFAULT_SEED,
         control_flow=True,
@@ -1103,7 +1103,7 @@ def get_ibm_heron_156() -> Target:
     backend = GenericBackendV2(
         num_qubits=156,
         coupling_map=cmap,
-        basis_gates=get_gateset_without_control_flow_ops("ibm_heron"),
+        basis_gates=get_gateset("ibm_heron"),
         noise_info=True,
         seed=DEFAULT_SEED,
         control_flow=True,

--- a/src/mqt/bench/targets/gatesets/__init__.py
+++ b/src/mqt/bench/targets/gatesets/__init__.py
@@ -17,7 +17,7 @@ import inspect
 from functools import cache
 from typing import TYPE_CHECKING
 
-from qiskit.circuit import CONTROL_FLOW_OP_NAMES, Parameter
+from qiskit.circuit import Parameter
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 from qiskit.providers.fake_provider import GenericBackendV2
 
@@ -40,7 +40,6 @@ _IMPORTED_MODULES: set[str] = set()
 __all__ = [
     "get_available_gateset_names",
     "get_gateset",
-    "get_gateset_without_control_flow_ops",
     "get_target_for_gateset",
     "register_gateset",
 ]
@@ -101,15 +100,8 @@ def get_gateset(gateset_name: str) -> list[str]:
     return _get_gateset(gateset_name).copy()
 
 
-def get_gateset_without_control_flow_ops(gateset_name: str) -> list[str]:
-    """Return the basis-gate list for gateset_name, without control-flow operations."""
-    return [gate for gate in _get_gateset(gateset_name) if gate not in CONTROL_FLOW_OP_NAMES]
-
-
 def _lazy_custom_gates() -> dict[str, Callable[[], Gate | type[Instruction]]]:
     """Import custom gates only when needed."""
-    from qiskit.circuit import IfElseOp  # noqa: PLC0415
-
     from .ionq import GPI2Gate, GPIGate, MSGate, ZZGate  # noqa: PLC0415
     from .rigetti import RXPI2DgGate, RXPI2Gate, RXPIGate  # noqa: PLC0415
 
@@ -121,7 +113,6 @@ def _lazy_custom_gates() -> dict[str, Callable[[], Gate | type[Instruction]]]:
         "rxpi": lambda: RXPIGate,
         "rxpi2": lambda: RXPI2Gate,
         "rxpi2dg": lambda: RXPI2DgGate,
-        "if_else": lambda: IfElseOp,
     }
 
 
@@ -137,7 +128,7 @@ def _get_target_for_gateset(gateset_name: str, num_qubits: int) -> Target:
             standard_gates.append(gate)
         else:
             other_gates.append(gate)
-    backend = GenericBackendV2(num_qubits=num_qubits, basis_gates=standard_gates)
+    backend = GenericBackendV2(num_qubits=num_qubits, basis_gates=standard_gates, control_flow=True)
     target = backend.target
     target.description = gateset_name
 

--- a/src/mqt/bench/targets/gatesets/clifford_t.py
+++ b/src/mqt/bench/targets/gatesets/clifford_t.py
@@ -35,7 +35,6 @@ def get_clifford_t_gateset() -> list[str]:
         "iswap",
         "dcx",
         "ecr",
-        "if_else",
     ]
 
 

--- a/src/mqt/bench/targets/gatesets/ibm.py
+++ b/src/mqt/bench/targets/gatesets/ibm.py
@@ -16,16 +16,16 @@ from ._registry import register_gateset
 @register_gateset("ibm_falcon")
 def get_ibm_falcon_gateset() -> list[str]:
     """Returns the basis gates of the IBM Falcon gateset."""
-    return ["id", "x", "sx", "rz", "cx", "if_else"]
+    return ["id", "x", "sx", "rz", "cx"]
 
 
 @register_gateset("ibm_eagle")
 def get_ibm_eagle_gateset() -> list[str]:
     """Returns the basis gates of the IBM Eagle gateset."""
-    return ["id", "x", "sx", "rz", "ecr", "if_else"]
+    return ["id", "x", "sx", "rz", "ecr"]
 
 
 @register_gateset("ibm_heron")
 def get_ibm_heron_gateset() -> list[str]:
     """Returns the basis gates of the IBM Heron gateset."""
-    return ["id", "x", "sx", "rz", "cz", "if_else"]
+    return ["id", "x", "sx", "rz", "cz"]

--- a/src/mqt/bench/targets/gatesets/ionq.py
+++ b/src/mqt/bench/targets/gatesets/ionq.py
@@ -54,13 +54,13 @@ if TYPE_CHECKING:
 @register_gateset("ionq_forte")
 def get_ionq_forte_gateset() -> list[str]:
     """Returns the basis gates of the IonQ Forte gateset."""
-    return ["rz", "gpi", "gpi2", "zz", "measure", "if_else"]
+    return ["rz", "gpi", "gpi2", "zz", "measure"]
 
 
 @register_gateset("ionq_aria")
 def get_ionq_aria_gateset() -> list[str]:
     """Returns the basis gates of the IonQ Aria gateset."""
-    return ["rz", "gpi", "gpi2", "ms", "measure", "if_else"]
+    return ["rz", "gpi", "gpi2", "ms", "measure"]
 
 
 class GPIGate(Gate):

--- a/src/mqt/bench/targets/gatesets/iqm.py
+++ b/src/mqt/bench/targets/gatesets/iqm.py
@@ -16,4 +16,4 @@ from ._registry import register_gateset
 @register_gateset("iqm")
 def get_iqm_gateset() -> list[str]:
     """Returns the basis gates of the IQM gateset."""
-    return ["r", "cz", "if_else"]
+    return ["r", "cz"]

--- a/src/mqt/bench/targets/gatesets/quantinuum.py
+++ b/src/mqt/bench/targets/gatesets/quantinuum.py
@@ -16,4 +16,4 @@ from ._registry import register_gateset
 @register_gateset("quantinuum")
 def get_quantinuum_gateset() -> list[str]:
     """Returns the basis gates of the Quantinuum gateset."""
-    return ["rx", "ry", "rz", "rzz", "if_else"]
+    return ["rx", "ry", "rz", "rzz"]

--- a/src/mqt/bench/targets/gatesets/rigetti.py
+++ b/src/mqt/bench/targets/gatesets/rigetti.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 @register_gateset("rigetti")
 def get_rigetti_gateset() -> list[str]:
     """Returns the basis gates of the Rigetti gateset."""
-    return ["rxpi", "rxpi2", "rxpi2dg", "rz", "iswap", "measure", "if_else"]
+    return ["rxpi", "rxpi2", "rxpi2dg", "rz", "iswap", "measure"]
 
 
 class RXPIGate(Gate):

--- a/uv.lock
+++ b/uv.lock
@@ -799,11 +799,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -2041,11 +2041,11 @@ parser = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2325,26 +2325,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.3.8"
+version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/ee/03e8180e3fda9de25b6480bd15cc2bde40d573868d50648b0e527b35562f/prek-0.3.8.tar.gz", hash = "sha256:434a214256516f187a3ab15f869d950243be66b94ad47987ee4281b69643a2d9", size = 400224, upload-time = "2026-03-23T08:23:35.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ff/5b7a2a9c4fa3dd2ffc8b13a9ec22aa550deda5b39ab273f8e02863b12642/prek-0.3.9.tar.gz", hash = "sha256:f82b92d81f42f1f90a47f5fbbf492373e25ef1f790080215b2722dd6da66510e", size = 423801, upload-time = "2026-04-13T12:30:38.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/84/40d2ddf362d12c4cd4a25a8c89a862edf87cdfbf1422aa41aac8e315d409/prek-0.3.8-py3-none-linux_armv6l.whl", hash = "sha256:6fb646ada60658fa6dd7771b2e0fb097f005151be222f869dada3eb26d79ed33", size = 5226646, upload-time = "2026-03-23T08:23:18.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/52/7308a033fa43b7e8e188797bd2b3b017c0f0adda70fa7af575b1f43ea888/prek-0.3.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3d7fdadb15efc19c09953c7a33cf2061a70f367d1e1957358d3ad5cc49d0616", size = 5620104, upload-time = "2026-03-23T08:23:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b1/f106ac000a91511a9cd80169868daf2f5b693480ef5232cec5517a38a512/prek-0.3.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72728c3295e79ca443f8c1ec037d2a5b914ec73a358f69cf1bc1964511876bf8", size = 5199867, upload-time = "2026-03-23T08:23:38.066Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e9/970713f4b019f69de9844e1bab37b8ddb67558e410916f4eb5869a696165/prek-0.3.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:48efc28f2f53b5b8087efca9daaed91572d62df97d5f24a1c7a087fecb5017de", size = 5441801, upload-time = "2026-03-23T08:23:32.617Z" },
-    { url = "https://files.pythonhosted.org/packages/12/a4/7ef44032b181753e19452ec3b09abb3a32607cf6b0a0508f0604becaaf2b/prek-0.3.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6ca9d63bacbc448a5c18e955c78d3ac5176c3a17c3baacdd949b1a623e08a36", size = 5155107, upload-time = "2026-03-23T08:23:31.021Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/77/4d9c8985dbba84149760785dfe07093ea1e29d710257dfb7c89615e2234c/prek-0.3.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1000f7029696b4fe712fb1fefd4c55b9c4de72b65509c8e50296370a06f9dc3f", size = 5566541, upload-time = "2026-03-23T08:23:45.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1a/81e6769ac1f7f8346d09ce2ab0b47cf06466acd9ff72e87e5d1f0d98cd32/prek-0.3.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ff0bed0e2c1286522987d982168a86cbbd0d069d840506a46c9fda983515517", size = 6552991, upload-time = "2026-03-23T08:23:21.958Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/fa/ce2df0dd2dc75a9437a52463239d0782998943d7b04e191fb89b83016c34/prek-0.3.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb087ac0ffda3ac65bbbae9a38326a7fd27ee007bb4a94323ce1eb539d8bbec", size = 5832972, upload-time = "2026-03-23T08:23:20.258Z" },
-    { url = "https://files.pythonhosted.org/packages/18/6b/9d4269df9073216d296244595a21c253b6475dfc9076c0bd2906be7a436c/prek-0.3.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e1e5e206ff7b31bd079cce525daddc96cd6bc544d20dc128921ad92f7a4c85d", size = 5448371, upload-time = "2026-03-23T08:23:41.835Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1d/1e4d8a78abefa5b9d086e5a9f1638a74b5e540eec8a648d9946707701f29/prek-0.3.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dcea3fe23832a4481bccb7c45f55650cb233be7c805602e788bb7dba60f2d861", size = 5270546, upload-time = "2026-03-23T08:23:24.231Z" },
-    { url = "https://files.pythonhosted.org/packages/77/07/34f36551a6319ae36e272bea63a42f59d41d2d47ab0d5fb00eb7b4e88e87/prek-0.3.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:4d25e647e9682f6818ab5c31e7a4b842993c14782a6ffcd128d22b784e0d677f", size = 5124032, upload-time = "2026-03-23T08:23:26.368Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/01/6d544009bb655e709993411796af77339f439526db4f3b3509c583ad8eb9/prek-0.3.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:de528b82935e33074815acff3c7c86026754d1212136295bc88fe9c43b4231d5", size = 5432245, upload-time = "2026-03-23T08:23:47.877Z" },
-    { url = "https://files.pythonhosted.org/packages/54/96/1237ee269e9bfa283ffadbcba1f401f48a47aed2b2563eb1002740d6079d/prek-0.3.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6d660f1c25a126e6d9f682fe61449441226514f412a4469f5d71f8f8cad56db2", size = 5950550, upload-time = "2026-03-23T08:23:43.8Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6b/a574411459049bc691047c9912f375deda10c44a707b6ce98df2b658f0b3/prek-0.3.8-py3-none-win32.whl", hash = "sha256:b0c291c577615d9f8450421dff0b32bfd77a6b0d223ee4115a1f820cb636fdf1", size = 4949501, upload-time = "2026-03-23T08:23:16.338Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b4/46b59fe49f635acd9f6530778ce577f9d8b49452835726a5311ffc902c67/prek-0.3.8-py3-none-win_amd64.whl", hash = "sha256:bc147fdbdd4ec33fc7a987b893ecb69b1413ac100d95c9889a70f3fd58c73d06", size = 5346551, upload-time = "2026-03-23T08:23:34.501Z" },
-    { url = "https://files.pythonhosted.org/packages/53/05/9cca1708bb8c65264124eb4b04251e0f65ce5bfc707080bb6b492d5a0df7/prek-0.3.8-py3-none-win_arm64.whl", hash = "sha256:a2614647aeafa817a5802ccb9561e92eedc20dcf840639a1b00826e2c2442515", size = 5190872, upload-time = "2026-03-23T08:23:29.463Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/08/c11a6b7834b461223763b6b1552f32c9199393685d52d555de621e900ee7/prek-0.3.9-py3-none-linux_armv6l.whl", hash = "sha256:3ed793d51bfaa27bddb64d525d7acb77a7c8644f549412d82252e3eb0b88aad8", size = 5337784, upload-time = "2026-04-13T12:30:46.044Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d9/974b02832a645c6411069c713e3191ce807f9962006da108e4727efd2fa1/prek-0.3.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:399c58400c0bd0b82a93a3c09dc1bfd88d8d0cfb242d414d2ed247187b06ead1", size = 5713864, upload-time = "2026-04-13T12:30:27.007Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e1/4ed14bef15eb30039a75177b0807ac007095a5a110284706ccf900a8d512/prek-0.3.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ea1ffb124e92f081b8e2ca5b5a623a733efb3be0c5b1f4b7ffe2ee17d1f20c", size = 5290437, upload-time = "2026-04-13T12:30:30.658Z" },
+    { url = "https://files.pythonhosted.org/packages/67/80/d5c3015e9da161dede566bfeef41f098f92470613157daa4f7377ab08d58/prek-0.3.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:aaf639f95b7301639298311d8d44aad0d0b4864e9736083ad3c71ce9765d37ab", size = 5536208, upload-time = "2026-04-13T12:30:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/8cdc5eb1018437d7828740defd322e7a96459c02fc8961160c4120325313/prek-0.3.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff104863b187fa443ea8451ca55d51e2c6e94f99f00d88784b5c3c4c623f1ebe", size = 5251785, upload-time = "2026-04-13T12:30:39.78Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e2/a5fc35a0fd3167224a000ca1b6235ecbdea0ac77e24af5979a75b0e6b5a4/prek-0.3.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:039ecaf87c63a3e67cca645ebd5bc5eb6aafa6c9d929e9a27b2921e7849d7ef9", size = 5668548, upload-time = "2026-04-13T12:30:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e8/a189ee79f401c259f66f8af587f899d4d5bfb04e0ca371bfd01e49871007/prek-0.3.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3bde2a3d045705095983c7f78ba04f72a7565fe1c2b4e85f5628502a254754ff", size = 6660927, upload-time = "2026-04-13T12:30:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28a0960a21543563e2c8e19aaad176cc8423a87aac3c914d0f313030d7a9244a", size = 5932244, upload-time = "2026-04-13T12:30:49.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/e88d4361f59be7adeeb3a8a3819d69d286d86fe6f7606840af6734362675/prek-0.3.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0dfb5d5171d7523271909246ee306b4dc3d5b63752e7dd7c7e8a8908fc9490d1", size = 5542139, upload-time = "2026-04-13T12:30:41.266Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1f/204837115087bb8d063bda754a7fe975428c5d5b6548c30dd749f8ab85d4/prek-0.3.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82b791bd36c1430c84d3ae7220a85152babc7eaf00f70adcb961bd594e756ba3", size = 5392519, upload-time = "2026-04-13T12:30:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/00/de57b5795e670b6d38e7eda6d9ac6fd6d757ca22f725e5054b042104cd53/prek-0.3.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:6eac6d2f736b041118f053a1487abed468a70dd85a8688eaf87bb42d3dcecf20", size = 5222780, upload-time = "2026-04-13T12:30:36.576Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/14/0bc055c305d92980b151f2ec00c14d28fe94c6d51180ca07fded28771cbf/prek-0.3.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:5517e46e761367a3759b3168eabc120840ffbca9dfbc53187167298a98f87dc4", size = 5524310, upload-time = "2026-04-13T12:30:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d1/eebc2b69be0de36cd84adbe0a0710f4deb468a90e30525be027d6db02d54/prek-0.3.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:92024778cf78683ca32687bb249ab6a7d5c33887b5ee1d1a9f6d0c14228f4cf3", size = 6043751, upload-time = "2026-04-13T12:30:29.101Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cb/be98c04e702cbc0b0328cd745ff4634ace69ad5a84461bde36f88a7be873/prek-0.3.9-py3-none-win32.whl", hash = "sha256:7f89c55e5f480f5d073769e319924ad69d4bf9f98c5cb46a83082e26e634c958", size = 5045940, upload-time = "2026-04-13T12:30:42.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b6/b51771d69f6282e34edeb73f23d956da34f2cabbb5ba16ba175cc0a056f9/prek-0.3.9-py3-none-win_amd64.whl", hash = "sha256:7722f3372eaa83b147e70a43cb7b9fe2128c13d0c78d8a1cdbf2a8ec2ee071eb", size = 5435204, upload-time = "2026-04-13T12:30:51.482Z" },
+    { url = "https://files.pythonhosted.org/packages/30/8a/f8a87c15b095460eccd67c8d89a086b7a37aac8d363f89544b8ce6ec653d/prek-0.3.9-py3-none-win_arm64.whl", hash = "sha256:0bced6278d6cc8a4b46048979e36bc9da034611dc8facd77ab123177b833a929", size = 5279552, upload-time = "2026-04-13T12:30:53.011Z" },
 ]
 
 [[package]]
@@ -2720,7 +2720,7 @@ wheels = [
 
 [[package]]
 name = "qiskit"
-version = "2.3.1"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -2732,15 +2732,15 @@ dependencies = [
     { name = "stevedore" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/9a/a366dd56b6a4520e5b2856e47d573c6813b4c3f62f28969a37205fd845ab/qiskit-2.3.1.tar.gz", hash = "sha256:7b3b7e1c8a50f7f423204143a1bd9f21bf27659c57459d582eaff4035d8d7f75", size = 3909915, upload-time = "2026-03-13T00:43:03.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/cb/a348ec6595a8a2163fad714692c5b2d82ffb6a7f82e7a64f5a58e0dbc37e/qiskit-2.4.0.tar.gz", hash = "sha256:57a43f869608fd8319444c2c1fbf6674fa36c6346646e41f4b128233693970d6", size = 4080145, upload-time = "2026-04-16T17:21:13.532Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/70/dba6afec66d2bf4df64b7059cd144bf0c775d998cb57b941d1065b331d28/qiskit-2.3.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:25a85465e8c860627e8a565cb9af824b2df1a2c42f5958b1a7b014aa085b32d6", size = 8614500, upload-time = "2026-03-13T02:30:24.247Z" },
-    { url = "https://files.pythonhosted.org/packages/55/0b/47d67d58b4de120e10d49255b635429bc162a982b0cd58cf75b1a9f594fa/qiskit-2.3.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b1404b72987d0c7db32203a87565775115f6a77b2a3539d40eb1e354df6d08bb", size = 7819922, upload-time = "2026-03-13T00:42:54.205Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f0/2af86ce0e11b06248bc6a66550acf98c19e606cb317c27bab4fbed2ce37f/qiskit-2.3.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68eec14320654065a158bf73b3d6fffaa31e865fe61b0db1510cfeeea76c87b0", size = 8176336, upload-time = "2026-03-13T00:42:56.891Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/fc/0bf71353c68b9090ed05e5c1d08730301c58a2b00f3001f0050f032bdcc9/qiskit-2.3.1-cp310-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:96545ad531c5e2ff6eecd348501620e0db0f3d73f49c20037ec3b5b2e9268f94", size = 8915234, upload-time = "2026-03-13T02:30:27.055Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/0c/19ffdb15d2e72156de406fe27cad26c6015071a385e6b48c6db87d8ce676/qiskit-2.3.1-cp310-abi3-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a1a030b4a0cd75f3299c9866a3e9489a02078efc343abd42eec74ad2a5f2fa80", size = 8513126, upload-time = "2026-03-13T02:30:30.288Z" },
-    { url = "https://files.pythonhosted.org/packages/11/06/41f4197fcb3c38e99f22f400ea25375c9057190cd094cd6c0f97be730796/qiskit-2.3.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:350027279bb171e9746fee5756c674872df97f4608b079129d4edb25b5bb1fdd", size = 8833222, upload-time = "2026-03-13T00:42:59.092Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/db/6ddc52eaf22ab1f95ee6251ff7a375c0a1a7453b5864528992303b166198/qiskit-2.3.1-cp310-abi3-win_amd64.whl", hash = "sha256:f884abd92c0173e246705f89f8b4808badaa0e1b167ed3277a3cb83c2564b4b8", size = 8639580, upload-time = "2026-03-13T00:43:01.022Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/cc/47fa03c0a52d603f978b95bc45c0f99bd436bc172f0727fe0f63f2758ce7/qiskit-2.4.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a6dfd5875a77736749e851c631ff5a328dc60e863c8b0aafd60fdc745a4c7591", size = 9350416, upload-time = "2026-04-16T19:34:53.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/37/9744dedced76513cb5517a574e268adaa8c10d127eb8add72a6236b3f51e/qiskit-2.4.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4ff99307a8fac97962964b02afe22ae7ee4997a49e98538599ff4b44e6659d31", size = 8328830, upload-time = "2026-04-16T17:21:02.609Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/70/fbd7634fbd66fe6419741051e00d719398466fc437e4cb148effeb057ce1/qiskit-2.4.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5352c66c5affd54dfb2473e99247031aaaf3af6c7cefe0875a0bd302ca31fcc1", size = 8625281, upload-time = "2026-04-16T17:21:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/1167314fb2c0d31f41975201604708ddef83192a9289e05f69a32898804a/qiskit-2.4.0-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:fd04cfb30b59fd257a1108fd6f337eceafd26039c8e86603bcced9b45137971f", size = 9680387, upload-time = "2026-04-16T19:34:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c4/6e639125851e3d6b709aea0d71b10ffc8fce14af322d2de6112cf57627f7/qiskit-2.4.0-cp310-abi3-manylinux_2_28_s390x.whl", hash = "sha256:446c8d6da61e9e134ba5e30f933240ce9920f668d0e010fc79cc5a22c03e9a78", size = 9186598, upload-time = "2026-04-16T19:34:58.786Z" },
+    { url = "https://files.pythonhosted.org/packages/62/55/1e6d61a1c8a83d685d281f5ae15e7c2c62080aed358a9c4b79309aa393d9/qiskit-2.4.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cf9020bf79934c7bf490973d99b80464957efc1fa13456d680c42bce23262687", size = 9329265, upload-time = "2026-04-16T17:21:08.193Z" },
+    { url = "https://files.pythonhosted.org/packages/94/26/b4d51da621e80a3aa4fccf72502f218773bb2f1bd63f9979e8a7b33ffaaf/qiskit-2.4.0-cp310-abi3-win_amd64.whl", hash = "sha256:0292d0d247f1603c225c3e83897aa8c93bc3010523f337f766750f70a8fff5ba", size = 9111120, upload-time = "2026-04-16T17:21:10.623Z" },
 ]
 
 [package.optional-dependencies]
@@ -3795,7 +3795,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.1"
+version = "21.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3804,9 +3804,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c5/aff062c66b42e2183201a7ace10c6b2e959a9a16525c8e8ca8e59410d27a/virtualenv-21.2.1.tar.gz", hash = "sha256:b66ffe81301766c0d5e2208fc3576652c59d44e7b731fc5f5ed701c9b537fa78", size = 5844770, upload-time = "2026-04-09T18:47:11.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/0e/f083a76cb590e60dff3868779558eefefb8dfb7c9ed020babc7aa014ccbf/virtualenv-21.2.1-py3-none-any.whl", hash = "sha256:bd16b49c53562b28cf1a3ad2f36edb805ad71301dee70ddc449e5c88a9f919a2", size = 5828326, upload-time = "2026-04-09T18:47:09.331Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]
@@ -3820,9 +3820,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.23.0"
+version = "3.23.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Description

This PR fixes an incompatibility with Qiskit 2.4 that was recently released.
I can't yet fully pin it down, but apparently something related to control flow and/or IfElse handling in the GenericBackendV2 class or around it changed in connection to the Clifford+T gate set we are building.
This is just a quick fix that makes the pipeline work again.
In the future, we should switch to the dedicated Clifford+T pipeline and the corresponding utility functions provided by Qiskit since 2.4

This PR also directly prepares the 2.2.2 release to quickly make MQT Bench work again with the latest Qiskit version.

Fixes #888 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/bench/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
