### PR TITLE
🐛 make crystal devices bidirectional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Make IQM Crystal device connectivity bidirectional ([#914]) ([**@flowerthrower**])
+
 ## [2.2.2] - 2026-04-20
 
 ### Fixed
@@ -122,6 +126,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#914]: https://github.com/munich-quantum-toolkit/bench/pull/914
 [#895]: https://github.com/munich-quantum-toolkit/bench/pull/895
 [#865]: https://github.com/munich-quantum-toolkit/bench/pull/865
 [#816]: https://github.com/munich-quantum-toolkit/bench/pull/816
@@ -175,6 +180,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 [**@soroushfathi**]: https://github.com/soroushfathi
 [**@adnathanail**]: https://github.com/adnathanail
 [**@TomasVF**]: https://github.com/TomasVF
+[**@flowerthrower**]: https://github.com/flowerthrower
 
 <!-- General links -->
 

--- a/src/mqt/bench/targets/devices/iqm.py
+++ b/src/mqt/bench/targets/devices/iqm.py
@@ -23,7 +23,7 @@ def get_iqm_crystal_5() -> Target:
     return _build_iqm_target(
         name="iqm_crystal_5",
         num_qubits=5,
-        connectivity=[[0, 2], [2, 0], [1, 2], [2, 1], [3, 2], [2, 3], [4, 2], [2, 4]],
+        connectivity=[[0, 2], [1, 2], [3, 2], [4, 2]],
         oneq_error=0.00132,
         twoq_error=0.0311,
         readout_error=0.0278,
@@ -215,6 +215,8 @@ def _build_iqm_target(
     target.add_instruction(Measure(), measure_props)
 
     # === Add two-qubit gates ===
+    # Account for bidirectionality of CZ gate
+    connectivity += [[q1, q0] for q0, q1 in connectivity]
     cz_props = {(q1, q2): InstructionProperties(duration=twoq_duration, error=twoq_error) for q1, q2 in connectivity}
     target.add_instruction(CZGate(), cz_props)
 

--- a/src/mqt/bench/targets/devices/iqm.py
+++ b/src/mqt/bench/targets/devices/iqm.py
@@ -199,7 +199,7 @@ def _build_iqm_target(
     twoq_duration: float,
     readout_duration: float,
 ) -> Target:
-    """Construct a hardcoded IQM target using mean values."""
+    """Construct a hardcoded IQM target using mean values and bidirectional connectivity."""
     target = Target(num_qubits=num_qubits, description=name)
 
     theta = Parameter("theta")

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -166,12 +166,14 @@ DEVICE_SPECS: Sequence[DeviceSpec] = [
         num_qubits=20,
         single_qubit_gates={"r", "measure"},
         two_qubit_gates={"cz"},
+        symmetric_connectivity={"cz": True},
     ),
     DeviceSpec(
         name="iqm_crystal_54",
         num_qubits=54,
         single_qubit_gates={"r", "measure"},
         two_qubit_gates={"cz"},
+        symmetric_connectivity={"cz": True},
     ),
     # ────────────────────────────────────────────────────────────── Quantinuum ──
     DeviceSpec(


### PR DESCRIPTION
## Description

Makes IQM crystal device connectivity bidirectional.

Fixes #913
## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.
