### PR TITLE
✨ Add Iterative Quantum Phase Estimation (IQPE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- ✨ Add Iterative Quantum Phase Estimation (IQPE) benchmark ([#925]) ([**@johanneswittmann9**])
+
 ### Fixed
 
 - 🐛 Make IQM Crystal device connectivity bidirectional ([#914]) ([**@flowerthrower**])
@@ -126,6 +130,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#925]: https://github.com/munich-quantum-toolkit/bench/pull/925
 [#914]: https://github.com/munich-quantum-toolkit/bench/pull/914
 [#895]: https://github.com/munich-quantum-toolkit/bench/pull/895
 [#865]: https://github.com/munich-quantum-toolkit/bench/pull/865
@@ -181,6 +186,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 [**@adnathanail**]: https://github.com/adnathanail
 [**@TomasVF**]: https://github.com/TomasVF
 [**@flowerthrower**]: https://github.com/flowerthrower
+[**@johanneswittmann9**]: https://github.com/johanneswittmann9
 
 <!-- General links -->
 

--- a/src/mqt/bench/benchmarks/iqpe.py
+++ b/src/mqt/bench/benchmarks/iqpe.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""IQPE benchmark definition."""
+
+from __future__ import annotations
+
+import random
+from fractions import Fraction
+
+import numpy as np
+from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
+
+from ._registry import register_benchmark
+
+
+@register_benchmark("iqpe", description="Iterative Quantum Phase Estimation (IQPE)")
+def create_circuit(num_qubits: int, exact: bool = True) -> QuantumCircuit:
+    """Returns a quantum circuit implementing the Iterative Quantum Phase Estimation algorithm.
+
+    Arguments:
+        num_qubits: Number of qubits of the returned quantum circuit. Must be at least 2.
+        exact: Whether to use the exact version of the algorithm.
+
+    Returns:
+        QuantumCircuit: A quantum circuit implementing the Iterative Quantum Phase Estimation algorithm.
+    """
+    if num_qubits <= 1:
+        msg = "Number of qubits must be at least 2 for IQPE."
+        raise ValueError(msg)
+
+    num_iterations = num_qubits - 1  # one ancilla qubit, rest for iterations
+    ancilla = QuantumRegister(1, "q")
+    psi = QuantumRegister(1, "psi")
+    c = ClassicalRegister(num_iterations, "c")
+    qc = QuantumCircuit(ancilla, psi, c, name="iqpe")
+
+    # get random n-bit string as target phase
+    random.seed(10)
+    theta = 0
+    if exact:
+        while theta == 0:
+            theta = random.getrandbits(num_iterations)
+        lam = Fraction(theta, 1 << num_iterations)  # phase to be estimated
+
+    elif not exact:
+        while theta == 0 or (theta & 1) == 0:  # Ensure an odd theta so phase cannot be exactly represented with n bits
+            theta = random.getrandbits(num_iterations)
+        lam = Fraction(theta, 1 << (num_iterations + 1))  # phase to be estimated, with extra bit
+
+    qc.x(psi)  # prepare |1> state
+
+    for i in range(num_iterations, 0, -1):  # start from n
+        qc.reset(ancilla[0])  # reset ancilla qubit
+        qc.h(ancilla[0])  # put ancilla in superposition
+
+        frac = (lam * (1 << (i - 1))) % 1  # exact Fraction in [0, 1)
+        angle = 2 * np.pi * float(frac)  # in [0, 2*pi)
+        if angle > np.pi:
+            angle -= 2 * np.pi  # shift into (-pi, pi]
+        qc.cp(angle, psi, ancilla[0])
+
+        for meas_idx in range(i, num_iterations):  # bits already measured this run
+            with qc.if_test((c[meas_idx], 1)):
+                rotation_angle = -2 * np.pi / (1 << (meas_idx - (i - 1) + 1))
+                if abs(rotation_angle) > 1e-10:  # avoid adding negligible gates
+                    qc.rz(rotation_angle, ancilla[0])
+
+        qc.h(ancilla[0])
+        qc.measure(ancilla[0], c[i - 1])
+
+    return qc

--- a/src/mqt/bench/benchmarks/iqpe.py
+++ b/src/mqt/bench/benchmarks/iqpe.py
@@ -20,12 +20,16 @@ from ._registry import register_benchmark
 
 
 @register_benchmark("iqpe", description="Iterative Quantum Phase Estimation (IQPE)")
-def create_circuit(num_qubits: int, exact: bool = True) -> QuantumCircuit:
+def create_circuit(
+    num_qubits: int, exact: bool = True, rotation_threshold: float = 1e-15, seed: int = 10
+) -> QuantumCircuit:
     """Returns a quantum circuit implementing the Iterative Quantum Phase Estimation algorithm.
 
     Arguments:
         num_qubits: Number of qubits of the returned quantum circuit. Must be at least 2.
         exact: Whether to use the exact version of the algorithm.
+        rotation_threshold: Threshold for adding rotation gates in the feedback step. Rotation gates with smaller angles will be omitted to reduce circuit complexity.
+        seed: Seed for the random number generator.
 
     Returns:
         QuantumCircuit: A quantum circuit implementing the Iterative Quantum Phase Estimation algorithm.
@@ -41,8 +45,8 @@ def create_circuit(num_qubits: int, exact: bool = True) -> QuantumCircuit:
     qc = QuantumCircuit(ancilla, psi, c, name="iqpe")
 
     # get random n-bit string as target phase
-    random.seed(10)
     theta = 0
+    random.seed(seed)
     if exact:
         while theta == 0:
             theta = random.getrandbits(num_iterations)
@@ -67,7 +71,7 @@ def create_circuit(num_qubits: int, exact: bool = True) -> QuantumCircuit:
         for meas_idx in range(i, num_iterations):  # bits already measured this run
             with qc.if_test((c[meas_idx], 1)):
                 rotation_angle = -2 * np.pi / (1 << (meas_idx - (i - 1) + 1))
-                if abs(rotation_angle) > 1e-10:  # avoid adding negligible gates
+                if abs(rotation_angle) > rotation_threshold:  # avoid adding negligible gates
                     qc.rz(rotation_angle, ancilla[0])
 
         qc.h(ancilla[0])

--- a/src/mqt/bench/benchmarks/iqpe.py
+++ b/src/mqt/bench/benchmarks/iqpe.py
@@ -80,6 +80,7 @@ def create_circuit(
 
         qc.h(ancilla[0])
         qc.measure(ancilla[0], c[i - 1])
-        qc.reset(ancilla[0])
+        with qc.if_test((c[i - 1], 1)):
+            qc.x(ancilla[0])  # reset ancilla for next iteration
 
     return qc

--- a/src/mqt/bench/benchmarks/iqpe.py
+++ b/src/mqt/bench/benchmarks/iqpe.py
@@ -56,7 +56,6 @@ def create_circuit(num_qubits: int, exact: bool = True) -> QuantumCircuit:
     qc.x(psi)  # prepare |1> state
 
     for i in range(num_iterations, 0, -1):  # start from n
-        qc.reset(ancilla[0])  # reset ancilla qubit
         qc.h(ancilla[0])  # put ancilla in superposition
 
         frac = (lam * (1 << (i - 1))) % 1  # exact Fraction in [0, 1)
@@ -73,5 +72,7 @@ def create_circuit(num_qubits: int, exact: bool = True) -> QuantumCircuit:
 
         qc.h(ancilla[0])
         qc.measure(ancilla[0], c[i - 1])
+        with qc.if_test((c[i - 1], 1)):
+            qc.x(ancilla[0])  # reset ancilla for next iteration
 
     return qc

--- a/src/mqt/bench/benchmarks/iqpe.py
+++ b/src/mqt/bench/benchmarks/iqpe.py
@@ -63,14 +63,15 @@ def create_circuit(
         qc.h(ancilla[0])  # put ancilla in superposition
 
         frac = (lam * (1 << (i - 1))) % 1  # exact Fraction in [0, 1)
-        angle = 2 * np.pi * float(frac)  # in [0, 2*pi)
+        angle = 2 * np.pi * frac  # in [0, 2*pi)
         if angle > np.pi:
             angle -= 2 * np.pi  # shift into (-pi, pi]
         qc.cp(angle, psi, ancilla[0])
 
         for meas_idx in range(i, num_iterations):  # bits already measured this run
             with qc.if_test((c[meas_idx], 1)):
-                rotation_angle = -2 * np.pi / (1 << (meas_idx - (i - 1) + 1))
+                exponent = meas_idx - (i - 1) + 1
+                rotation_angle = -2 * np.pi * Fraction(1, 1 << exponent)
                 if abs(rotation_angle) > rotation_threshold:  # avoid adding negligible gates
                     qc.rz(rotation_angle, ancilla[0])
 

--- a/src/mqt/bench/benchmarks/iqpe.py
+++ b/src/mqt/bench/benchmarks/iqpe.py
@@ -25,9 +25,14 @@ def create_circuit(
 ) -> QuantumCircuit:
     """Returns a quantum circuit implementing the Iterative Quantum Phase Estimation algorithm.
 
+    In contrast to the regular QPE algorithm, the @p num_qubits argument does not influence the final number of qubits of the circuit.
+    The circuit will always use exactly two qubits, but `num_qubits-1` iterations of the phase estimation loop.
+    This way, transforming the IQPE benchmark circuit to a straight-line circuit (by replacing reset operations with new qubits and applying the deferred measurement principle) results in the equivalent QPE benchmark circuit configured with the same value for `num_qubits`.
+    The name `num_qubits` is kept for consistency with the other benchmark generation functions.
+
     Arguments:
-        num_qubits: Number of qubits of the returned quantum circuit. Must be at least 2.
-        exact: Whether to use the exact version of the algorithm.
+        num_qubits: Controls the precision of the phase estimation algorithm. Must be at least 2.
+        exact: Whether to use a target phase that is exactly representable with the chosen precision.
         rotation_threshold: Threshold for adding rotation gates in the feedback step. Rotation gates with smaller angles will be omitted to reduce circuit complexity.
         seed: Seed for the random number generator.
 
@@ -64,8 +69,6 @@ def create_circuit(
 
         frac = (lam * (1 << (i - 1))) % 1  # exact Fraction in [0, 1)
         angle = 2 * np.pi * frac  # in [0, 2*pi)
-        if angle > np.pi:
-            angle -= 2 * np.pi  # shift into (-pi, pi]
         qc.cp(angle, psi, ancilla[0])
 
         for meas_idx in range(i, num_iterations):  # bits already measured this run
@@ -77,7 +80,6 @@ def create_circuit(
 
         qc.h(ancilla[0])
         qc.measure(ancilla[0], c[i - 1])
-        with qc.if_test((c[i - 1], 1)):
-            qc.x(ancilla[0])  # reset ancilla for next iteration
+        qc.reset(ancilla[0])
 
     return qc

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -84,6 +84,7 @@ SPECIAL_QUBIT_COUNTS: dict[str, int] = {
     "vbe_ripple_carry_adder": 4,
     "shors_nine_qubit_code": 17,
     "seven_qubit_steane_code": 13,
+    "iqpe": 2,
 }
 
 
@@ -204,6 +205,7 @@ def test_arithmetic_circuits(benchmark_name: str, input_value: int) -> None:
         ("vbe_ripple_carry_adder", 3, "unknown_adder", "kind must be 'full', 'half', or 'fixed'."),
         ("hhl", 2, None, "Number of qubits must be at least 3 for HHL."),
         ("qpeexact", 1, None, "Number of qubits must be at least 2 for QPE exact."),
+        ("iqpe", 1, None, "Number of qubits must be at least 2 for IQPE."),
         ("bmw_quark_copula", 3, None, "Number of qubits must be divisible by 2."),
         ("ae", 1, None, r"Number of qubits must be at least 2 \(1 evaluation \+ 1 target\)."),
         ("shors_nine_qubit_code", 9, None, "num_qubits must be divisible by 17."),

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -238,6 +238,19 @@ def test_bv() -> None:
         create_circuit("bv", 3, hidden_string="wrong")
 
 
+def test_iqpe() -> None:
+    """Test the creation of the IQPE benchmark."""
+    qc = create_circuit("iqpe", 4, exact=True)
+    assert qc.num_qubits == 2
+    assert qc.num_clbits == 3
+    assert "iqpe" in qc.name
+
+    qc = create_circuit("iqpe", 4, exact=False)
+    assert qc.num_qubits == 2
+    assert qc.num_clbits == 3
+    assert "iqpe" in qc.name
+
+
 def test_dj_constant_oracle() -> None:
     """Test the creation of the DJ benchmark constant oracle."""
     qc = create_circuit("dj", 5, False)

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -240,12 +240,12 @@ def test_bv() -> None:
 
 def test_iqpe() -> None:
     """Test the creation of the IQPE benchmark."""
-    qc = create_circuit("iqpe", 4, exact=True)
+    qc = create_circuit("iqpe", 4, exact=True, rotation_threshold=1e-10, seed=42)
     assert qc.num_qubits == 2
     assert qc.num_clbits == 3
     assert "iqpe" in qc.name
 
-    qc = create_circuit("iqpe", 4, exact=False)
+    qc = create_circuit("iqpe", 4, exact=False, rotation_threshold=1e-10, seed=42)
     assert qc.num_qubits == 2
     assert qc.num_clbits == 3
     assert "iqpe" in qc.name


### PR DESCRIPTION
## Description

Implementation of the Iterative Quantum Phase Estimation (IQPE) benchmark. The code is inspired by existing benchmarks `qpeexact` and `qpeinexact`, combining the two with an additional parameter `exact: bool`.
The circuit accepts a minimum of `num_qubits=2`, which is split into 1 ancillar qubit and I calculate `num_iterations = num_qubits - 1` iterations. The split of the `num_qubits` parameter was chosen to be consistent with the input and output of `qpeexact` and `qpeinexact`. 
It extracts the phase over `num_iterations` rounds using mid-circuit measurement with classical feedforward (if_test). In the inexact case an extra bit is added so the available iterations cannot represent the phase exactly. 

A few important details:
- The implementation is based on information found in this [Dobšíček et al.](https://journals.aps.org/pra/pdf/10.1103/PhysRevA.76.030306)
- To keep calculations from exploding, our phase is reduced to a fraction in [0, 1) and the angle is kept within (-pi, pi]
- For rotation angles, if they are close to 0, rotations are skipped.

Fixes #797

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/bench/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
